### PR TITLE
Fix license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2021 Omar Cornut
+Copyright (c) 2018 Jackson Seal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Sorry, earlier I copied the MIT license from another project without noticing it includes the name of the author. I fixed it now to match your other licenses.